### PR TITLE
feat(pagination): extracts pagination hook; modularizes pagination component

### DIFF
--- a/src/Pagination/Page.tsx
+++ b/src/Pagination/Page.tsx
@@ -1,55 +1,14 @@
-import React from "react";
+import React, { ElementType, FC, ReactNode } from "react";
 import { Button, ButtonProps } from "../Button";
 
-export type PageOnClick = {
-  event: React.MouseEvent<HTMLAnchorElement>;
-  pageNumber: number;
+export type PageProps = ButtonProps & {
+  as?: ElementType | keyof JSX.IntrinsicElements;
+  children: ReactNode;
 };
 
-export type PageProps = Omit<ButtonProps, "onClick"> & {
-  as?: "a" | React.ElementType;
-  children: JSX.Element | string | number;
-  currentPage: number;
-  href: string;
-  onClick?: ({ event, pageNumber }: PageOnClick) => void;
-  pageNumber: number;
-  per: number;
-  rel?: string;
-};
-
-export const Page: React.FC<PageProps> = ({
-  as = "a",
-  children,
-  currentPage,
-  href,
-  onClick,
-  pageNumber,
-  per,
-  ...rest
-}) => {
-  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    if (!onClick) return;
-    onClick({ event, pageNumber });
-  };
-
+export const Page: FC<PageProps> = ({ children, ...rest }) => {
   return (
-    <Button
-      flex="1"
-      textAlign="center"
-      as={as}
-      disabled={pageNumber === currentPage}
-      tabIndex={pageNumber === currentPage && -1}
-      onClick={handleClick}
-      {...(as === "a"
-        ? { href: `${href}?page=${pageNumber}&per=${per}` }
-        : {
-            to: {
-              pathname: href,
-              search: `?page=${pageNumber}&per=${per}`,
-            },
-          })}
-      {...rest}
-    >
+    <Button flex="1" textAlign="center" {...rest}>
       {children}
     </Button>
   );

--- a/src/Pagination/Pagination.stories.tsx
+++ b/src/Pagination/Pagination.stories.tsx
@@ -1,13 +1,9 @@
 import React, { useState } from "react";
 import { States } from "storybook-states";
 import { action } from "@storybook/addon-actions";
-import { Pagination, PaginationProps, Page, PageProps } from ".";
+import { Pagination, PaginationProps } from ".";
 
 export default { title: "Pagination", component: Pagination };
-
-const AltPage: React.FC<PageProps> = ({ href, children }) => (
-  <a href={href}>{children}</a>
-);
 
 export const Default = () => (
   <States<Partial<PaginationProps>>
@@ -18,20 +14,11 @@ export const Default = () => (
       { page: 20 },
       { per: 499 },
       { per: 500 },
-      { Page: AltPage },
       { variant: "small" },
       { onChange: action("onChange") },
     ]}
   >
-    <Pagination page={1} per={25} total={500} href="#page" />
-  </States>
-);
-
-export const PageLink = () => (
-  <States<Partial<PageProps>> states={[{}, { currentPage: 1 }]}>
-    <Page pageNumber={1} currentPage={2} per={2} href="#page">
-      1
-    </Page>
+    <Pagination page={1} per={25} total={500} />
   </States>
 );
 
@@ -40,13 +27,7 @@ export const Demo = () => {
 
   return (
     <States>
-      <Pagination
-        page={page}
-        per={25}
-        total={500}
-        href="#page"
-        onChange={setPage}
-      />
+      <Pagination page={page} per={25} total={500} onChange={setPage} />
     </States>
   );
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from "./useClickOutside";
 export * from "./useContrastingColor";
+export * from "./usePagination";
 export * from "./useUniqueId";
 export * from "./useUpdateEffect";

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,135 @@
+import { useMemo } from "react";
+
+export const PAGINATION_DEFAULT_PAGE = 1;
+export const PAGINATION_DEFAULT_PER = 24;
+export const PAGINATION_DEFAULT_INTERVAL = 3;
+
+export interface PaginationPage {
+  disabled: boolean;
+  label: string;
+  page: number;
+  rel?: "next" | "prev";
+  tabIndex?: number;
+}
+
+export interface UsePagination {
+  currentPage?: number;
+  interval?: number;
+  per?: number;
+  total: number;
+}
+
+export const usePagination = ({
+  currentPage = PAGINATION_DEFAULT_PAGE,
+  interval = PAGINATION_DEFAULT_INTERVAL,
+  per = PAGINATION_DEFAULT_PER,
+  total,
+}: UsePagination) => {
+  const totalPages = Math.ceil(total / per);
+  const prevPage = currentPage > 1 ? currentPage - 1 : currentPage;
+  const nextPage = currentPage < totalPages ? currentPage + 1 : currentPage;
+
+  const head: PaginationPage[] = [
+    {
+      label: "A",
+      page: 1,
+      disabled: disabled(1, currentPage),
+      tabIndex: tabIndex(1, currentPage),
+    },
+    {
+      label: "←",
+      page: prevPage,
+      disabled: disabled(prevPage, currentPage),
+      tabIndex: tabIndex(prevPage, currentPage),
+      rel: "prev",
+    },
+  ];
+
+  const tail: PaginationPage[] = [
+    {
+      label: "→",
+      page: nextPage,
+      disabled: disabled(nextPage, currentPage),
+      tabIndex: tabIndex(nextPage, currentPage),
+      rel: "next",
+    },
+    {
+      label: "Ω",
+      page: totalPages,
+      disabled: disabled(totalPages, currentPage),
+      tabIndex: tabIndex(totalPages, currentPage),
+    },
+  ];
+
+  const current: PaginationPage = {
+    label: `${currentPage}`,
+    page: currentPage,
+    disabled: disabled(currentPage, currentPage),
+    tabIndex: tabIndex(currentPage, currentPage),
+  };
+
+  const leftSurrounding: PaginationPage[] = useMemo(
+    () =>
+      [...Array(interval).keys()]
+        .map((i) => {
+          const page = currentPage - (i + 1);
+          return {
+            label: `${page}`,
+            page,
+            disabled: disabled(page, currentPage),
+            tabIndex: tabIndex(page, currentPage),
+          };
+        })
+        .filter((page) => page.page > 0)
+        .reverse(),
+    [currentPage, interval]
+  );
+
+  const rightSurrounding: PaginationPage[] = useMemo(
+    () =>
+      [...Array(interval).keys()]
+
+        .map((i) => {
+          const page = currentPage + (i + 1);
+          return {
+            label: `${page}`,
+            page,
+            disabled: disabled(page, currentPage),
+            tabIndex: tabIndex(page, currentPage),
+          };
+        })
+        .filter((page) => page.page <= totalPages),
+    [currentPage, interval, totalPages]
+  );
+
+  const center: PaginationPage[] = [
+    ...leftSurrounding,
+    current,
+    ...rightSurrounding,
+  ];
+
+  const pages: PaginationPage[] = [...head, ...center, ...tail];
+
+  return {
+    center,
+    current,
+    head,
+    leftSurrounding,
+    nextPage,
+    pages,
+    prevPage,
+    rightSurrounding,
+    tail,
+    totalPages,
+  };
+};
+
+const disabled = (page: number, currentPage: number) => {
+  return page === currentPage;
+};
+
+const tabIndex = (page: number, currentPage: number) => {
+  if (page === currentPage) {
+    return -1;
+  }
+};


### PR DESCRIPTION
Exposes a `usePagination` hook for building a custom pagination component.

BREAKING CHANGE: pagination no longer accepts href and just acts as a simple client-side pagination component/example